### PR TITLE
View usage examples locally and add experimental examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,21 +1,13 @@
 # Usage examples
 
 TransportAPI usage examples show how our endpoints can be used.
-They are intended for a technical audience, to provide inspiration for what can be built, and tutorials to get started,
-with code that can be reused in applications.
-The examples are mini web applications, written in HTML and javascript. They focus on processing data from the API,
-rather than style: we don't want functional code getting lost in a sea of styling.
-
-## Experimental examples
-
-The usage examples navigation page supports experimental usage examples to perform production quality inspection
-without affecting the user experience. The examples that are marked as experimental won't be shown unless an additional
-request parameter `showExperimental=true` is provided. 
-
-Example:
-https://developer.transportapi.com/examples?showExperimental=true
-
-To mark example as experimental add `experimental: true` to the listed `examples` in `main.js`
+They are intended for a technical audience, to provide inspiration for
+what can be built, and tutorials to get started, with code that can be
+reused in applications.
+The examples are mini web applications, written in HTML and javascript.
+They focus on processing data from the API,
+rather than style: we don't want functional code getting lost in
+a sea of styling.
 
 ## Development
 
@@ -23,42 +15,38 @@ To serve the page content on `localhost` execute:
 ```shell
 ruby -run -e httpd . -p 8080
 ```
-in the project root directory and open `http://localhost:8081/src`
+in the project root directory and open
+`http://localhost:8080/src?localDevelopment=true`
 
-The pages of each individual usage example use [CodeSandbox](https://codesandbox.io/) for the embedded example playground and
-https://raw.githubusercontent.com/ for the listed source files.
-They are both online and to load them properly you need to push your development branch and add its name
-as request parameter `branch`, otherwise your new usage examples won't be found and the changes to the existing ones
-won't be reflected.
+Please note that to see your local files you have to add query parameter
+`localDevelopment=true`, otherwise the template `.hbs` files will be loaded
+from GitHub pages and examples sources from raw.githubusercontent.com
+
+The pages of each individual usage example use
+[CodeSandbox](https://codesandbox.io/) for the embedded example playground.
+It is online and to load it with your local changes reflected you need to
+push your development branch and add its name as request parameter `branch`.
 
 Example:
-`http://localhost:8080/?example=bus-stop-timetable&branch=add-new-example`
 
-## Production setup
+`http://localhost:8080/?example=bus-stop-timetable&branch=<YOUR DEVELOPMENT BRANCH>`
 
-Currently `src/index.html` is manually copied to the `Usage examples` section in the 3scale CMS.
-(If you need to introduce some changes to this file you have to also reflect them there)
+## Reviewing examples
+### By using the local setup
 
-It loads `main.js` from [the Github Pages of the repository](https://transportapi.github.io/usage-examples/src). It is
-serving the content of the `master` branch.
+1. Run the usage examples locally (See [Development](#development))
+2. Open `http://localhost:8080/src?localDevelopment=true&branch=<REVIEWED BRANCH>`
+Please note that you have to manually add the
+`localDevelopment=true&branch=<REVIEWED BRANCH>`query parameters on each page.
 
-1. Usage examples index page
-`src/navigation.hbs` is loaded from https://raw.githubusercontent.com/transportapi/usage-examples/master/src/navigation.hbs
-`src/navigation.css` is loaded from https://transportapi.github.io/usage-examples/src/navigation.css because it provides the proper MIME type. 
+### By using experimental examples in production
 
-2. Usage example page
-`src/example.hbs` is loaded from https://raw.githubusercontent.com/transportapi/usage-examples/master/src/example.hbs
-`src/example.css` is loaded from https://transportapi.github.io/usage-examples/src/example.css because it provides the proper MIME type.
+The usage examples navigation page supports experimental usage examples
+to perform production quality inspection without affecting the user experience.
+The examples that are marked as experimental won't be shown unless an additional
+request parameter `showExperimental=true` is provided.
 
-The CodeSandbox playground is loaded from
-https://codesandbox.io/s/github/transportapi/usage-examples/tree/master/examples/<EXAMPLE_NAME>?from-embed
+Example:
+https://developer.transportapi.com/examples?showExperimental=true
 
-The usage example source files are loaded from
-https://raw.githubusercontent.com/transportapi/usage-examples/master/src/<EXAMPLE_NAME>/<FILE_NAME>
-
-## Deployment
-
-The usage examples page is deployed to https://developer.transportapi.com/examples on every merge to `master` 
-
-Please note that currently `src/index.html` is manually copied to the `Usage examples` section in the 3scale CMS.
-If you introduce any changes to `index.html` you should also reflect them in 3scale.
+To mark example as experimental add `experimental: true` to the listed `examples` in `main.js`

--- a/Readme.md
+++ b/Readme.md
@@ -15,30 +15,26 @@ To serve the page content on `localhost` execute:
 ruby -run -e httpd . -p 8080
 ```
 in the project root directory and open
-`http://localhost:8080/src?localDevelopment=true`
+`http://localhost:8080/src?localDevelopment=true&branch=<YOUR DEVELOPMENT BRANCH>`
 
 Please note that to see your local files you have to add query parameter
 `localDevelopment=true`, otherwise the template `.hbs` files will be loaded
 from GitHub pages and examples sources from raw.githubusercontent.com
 
-The pages of each  usage example use[CodeSandbox](https://codesandbox.io/)
-for the embedded example playground.
+The page of usage examples use [CodeSandbox](https://codesandbox.io/)
+for the embedded source playground.
 It is online and to load it with your local changes reflected you need to
-push your development branch and add its name as request parameter `branch`.
+push your development git branch and add its name as request parameter `branch`.
 
 Example:
 
-`http://localhost:8080/?example=bus-stop-timetable&localDevelopment=true&branch=<YOUR DEVELOPMENT BRANCH>`
+`http://localhost:8080/src?example=bus-stop-timetable&localDevelopment=true&branch=<YOUR DEVELOPMENT BRANCH>`
 
 ## Reviewing examples
 ### By using the local setup
 
 1. Run the usage examples locally (See [Development](#development))
 2. Open `http://localhost:8080/src?localDevelopment=true&branch=<REVIEWED BRANCH>`
-To load the Codesandbox playground for on usage example pages you have to
-3. manually add `branch=<REVIEWED BRANCH>` to the url.
-Example:
-`http://localhost:8080/src/?example=train-station-timetable&localDevelopment=true&branch=add-train-station-timetable-example`
 
 ### By using experimental examples in production
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,64 @@
+# Usage examples
+
+TransportAPI usage examples show how our endpoints can be used.
+They are intended for a technical audience, to provide inspiration for what can be built, and tutorials to get started,
+with code that can be reused in applications.
+The examples are mini web applications, written in HTML and javascript. They focus on processing data from the API,
+rather than style: we don't want functional code getting lost in a sea of styling.
+
+## Experimental examples
+
+The usage examples navigation page supports experimental usage examples to perform production quality inspection
+without affecting the user experience. The examples that are marked as experimental won't be shown unless an additional
+request parameter `showExperimental=true` is provided. 
+
+Example:
+https://developer.transportapi.com/examples?showExperimental=true
+
+To mark example as experimental add `experimental: true` to the listed `examples` in `main.js`
+
+## Development
+
+To serve the page content on `localhost` execute:
+```shell
+ruby -run -e httpd . -p 8080
+```
+in the project root directory and open `http://localhost:8081/src`
+
+The pages of each individual usage example use [CodeSandbox](https://codesandbox.io/) for the embedded example playground and
+https://raw.githubusercontent.com/ for the listed source files.
+They are both online and to load them properly you need to push your development branch and add its name
+as request parameter `branch`, otherwise your new usage examples won't be found and the changes to the existing ones
+won't be reflected.
+
+Example:
+`http://localhost:8080/?example=bus-stop-timetable&branch=add-new-example`
+
+## Production setup
+
+Currently `src/index.html` is manually copied to the `Usage examples` section in the 3scale CMS.
+(If you need to introduce some changes to this file you have to also reflect them there)
+
+It loads `main.js` from [the Github Pages of the repository](https://transportapi.github.io/usage-examples/src). It is
+serving the content of the `master` branch.
+
+1. Usage examples index page
+`src/navigation.hbs` is loaded from https://raw.githubusercontent.com/transportapi/usage-examples/master/src/navigation.hbs
+`src/navigation.css` is loaded from https://transportapi.github.io/usage-examples/src/navigation.css because it provides the proper MIME type. 
+
+2. Usage example page
+`src/example.hbs` is loaded from https://raw.githubusercontent.com/transportapi/usage-examples/master/src/example.hbs
+`src/example.css` is loaded from https://transportapi.github.io/usage-examples/src/example.css because it provides the proper MIME type.
+
+The CodeSandbox playground is loaded from
+https://codesandbox.io/s/github/transportapi/usage-examples/tree/master/examples/<EXAMPLE_NAME>?from-embed
+
+The usage example source files are loaded from
+https://raw.githubusercontent.com/transportapi/usage-examples/master/src/<EXAMPLE_NAME>/<FILE_NAME>
+
+## Deployment
+
+The usage examples page is deployed to https://developer.transportapi.com/examples on every merge to `master` 
+
+Please note that currently `src/index.html` is manually copied to the `Usage examples` section in the 3scale CMS.
+If you introduce any changes to `index.html` you should also reflect them in 3scale.

--- a/Readme.md
+++ b/Readme.md
@@ -21,8 +21,8 @@ Please note that to see your local files you have to add query parameter
 `localDevelopment=true`, otherwise the template `.hbs` files will be loaded
 from GitHub pages and examples sources from raw.githubusercontent.com
 
-The pages of each individual usage example use
-[CodeSandbox](https://codesandbox.io/) for the embedded example playground.
+The pages of each  usage example use[CodeSandbox](https://codesandbox.io/)
+for the embedded example playground.
 It is online and to load it with your local changes reflected you need to
 push your development branch and add its name as request parameter `branch`.
 
@@ -35,9 +35,10 @@ Example:
 
 1. Run the usage examples locally (See [Development](#development))
 2. Open `http://localhost:8080/src?localDevelopment=true&branch=<REVIEWED BRANCH>`
-Please note that you have to manually add the
-`localDevelopment=true&branch=<REVIEWED BRANCH>`query parameters to the url of
-each page.
+To load the Codesandbox playground for on usage example pages you have to
+3. manually add `branch=<REVIEWED BRANCH>` to the url.
+Example:
+`http://localhost:8080/src/?example=train-station-timetable&localDevelopment=true&branch=add-train-station-timetable-example`
 
 ### By using experimental examples in production
 

--- a/Readme.md
+++ b/Readme.md
@@ -5,9 +5,8 @@ They are intended for a technical audience, to provide inspiration for
 what can be built, and tutorials to get started, with code that can be
 reused in applications.
 The examples are mini web applications, written in HTML and javascript.
-They focus on processing data from the API,
-rather than style: we don't want functional code getting lost in
-a sea of styling.
+They focus on processing data from the API, rather than style:
+we don't want functional code getting lost in a sea of styling.
 
 ## Development
 
@@ -29,7 +28,7 @@ push your development branch and add its name as request parameter `branch`.
 
 Example:
 
-`http://localhost:8080/?example=bus-stop-timetable&branch=<YOUR DEVELOPMENT BRANCH>`
+`http://localhost:8080/?example=bus-stop-timetable&localDevelopment=true&branch=<YOUR DEVELOPMENT BRANCH>`
 
 ## Reviewing examples
 ### By using the local setup
@@ -37,16 +36,18 @@ Example:
 1. Run the usage examples locally (See [Development](#development))
 2. Open `http://localhost:8080/src?localDevelopment=true&branch=<REVIEWED BRANCH>`
 Please note that you have to manually add the
-`localDevelopment=true&branch=<REVIEWED BRANCH>`query parameters on each page.
+`localDevelopment=true&branch=<REVIEWED BRANCH>`query parameters to the url of
+each page.
 
 ### By using experimental examples in production
 
 The usage examples navigation page supports experimental usage examples
 to perform production quality inspection without affecting the user experience.
-The examples that are marked as experimental won't be shown unless an additional
-request parameter `showExperimental=true` is provided.
+The examples that are marked as experimental won't be shown unless an
+additional request parameter `showExperimental=true` is provided.
 
 Example:
 https://developer.transportapi.com/examples?showExperimental=true
 
-To mark example as experimental add `experimental: true` to the listed `examples` in `main.js`
+To mark example as experimental add `experimental: true` to the listed
+`examples` in `main.js`

--- a/examples/bus-stop-timetable/main.js
+++ b/examples/bus-stop-timetable/main.js
@@ -17,7 +17,7 @@ $.getJSON(url, data => {
       const service = departures[line][0]
       return `
         <tr>
-          // <td>${service.aimed_departure_time}</td>
+          <td>${service.aimed_departure_time}</td>
           <td>${service.line_name}</td>
           <td>${service.direction}</td>
         </tr>
@@ -27,7 +27,7 @@ $.getJSON(url, data => {
   const html = `
     <table>
       <tr>
-<!--        <th>Time</th>-->
+        <th>Time</th>
         <th>Line</th>
         <th>Destination</th>
       </tr>

--- a/examples/bus-stop-timetable/main.js
+++ b/examples/bus-stop-timetable/main.js
@@ -17,7 +17,7 @@ $.getJSON(url, data => {
       const service = departures[line][0]
       return `
         <tr>
-          <td>${service.aimed_departure_time}</td>
+          // <td>${service.aimed_departure_time}</td>
           <td>${service.line_name}</td>
           <td>${service.direction}</td>
         </tr>
@@ -27,7 +27,7 @@ $.getJSON(url, data => {
   const html = `
     <table>
       <tr>
-        <th>Time</th>
+<!--        <th>Time</th>-->
         <th>Line</th>
         <th>Destination</th>
       </tr>

--- a/src/example.hbs
+++ b/src/example.hbs
@@ -3,7 +3,7 @@
 <div class="container">
   <h1>{{title}}</h1>
   <p>{{description}}</p>
-  <iframe src="https://codesandbox.io/embed/github/transportapi/usage-examples/tree/master/examples/{{directory}}?hidenavigation=1&hidedevtools=1&view=preview&module=%2Fmain.js"
+  <iframe src="https://codesandbox.io/embed/github/transportapi/usage-examples/tree/{{branch}}/examples/{{directory}}?hidenavigation=1&hidedevtools=1&view=preview&module=%2Fmain.js"
           style="width:70em; height:500px; border:0; overflow:hidden;"
           sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts">
   </iframe>

--- a/src/main.js
+++ b/src/main.js
@@ -2,15 +2,18 @@
 
 const GITHUB_PAGES_URL = 'https://transportapi.github.io/usage-examples/src/'
 const RAW_GITHUB_CONTENT_URL = 'https://raw.githubusercontent.com/transportapi/usage-examples/master/'
+const LOCAL_DEVELOPMENT_QUERY_PARAM = 'localDevelopment'
+const BRANCH_QUERY_PARAM = 'branch'
+const SHOW_EXPERIMENTAL_QUERY_PARAM = 'showExperimental'
 
 const urlParams = new URLSearchParams(window.location.search)
 const showExperimental =
-  urlParams.has('showExperimental') ? JSON.parse(urlParams.get('showExperimental')) : false
-const gitBranch = urlParams.has('branch') ? urlParams.get('branch') : 'master'
+  urlParams.has(SHOW_EXPERIMENTAL_QUERY_PARAM) ? JSON.parse(urlParams.get(SHOW_EXPERIMENTAL_QUERY_PARAM)) : false
+const gitBranch = urlParams.has(BRANCH_QUERY_PARAM) ? urlParams.get(BRANCH_QUERY_PARAM) : 'master'
 
 // For local development load the files from a relative path
-const examplesRootUrl = urlParams.has('localDevelopment') ? '../' : RAW_GITHUB_CONTENT_URL
-const pageTemplatesRootUrl = urlParams.has('localDevelopment') ? '' : GITHUB_PAGES_URL
+const examplesRootUrl = urlParams.has(LOCAL_DEVELOPMENT_QUERY_PARAM) ? '../' : RAW_GITHUB_CONTENT_URL
+const pageTemplatesRootUrl = urlParams.has(LOCAL_DEVELOPMENT_QUERY_PARAM) ? '' : GITHUB_PAGES_URL
 
 const examples = [
   {
@@ -73,7 +76,7 @@ if (urlParams.has('example')) {
   const examplesToList = showExperimental ? examples : examples.filter(example => !example.experimental)
   const properties = {
     examples: examplesToList,
-    additionalUrlParameters: urlParams.has('localDevelopment') ? '&localDevelopment=true' : '',
+    additionalUrlQueryParams: exampleViewUrlQueryParameters(),
     showExample: showExample
   }
   loadTemplate('navigation.hbs', properties, () => null)
@@ -111,4 +114,20 @@ function showExample (exampleProperties) {
     // doesn't work without this approach
     setTimeout(() => Prism.highlightAll(), 0)
   })
+}
+
+function exampleViewUrlQueryParameters () {
+  const parameters = {};
+  // Parameter from the current view that if present should propagate to the example views
+  [LOCAL_DEVELOPMENT_QUERY_PARAM, BRANCH_QUERY_PARAM]
+    .filter(param => urlParams.has(param))
+    .forEach(param => {
+      parameters[param] = urlParams.get(param)
+    })
+  return toAdditionalQueryParametersString(parameters)
+}
+
+function toAdditionalQueryParametersString (parameters) {
+  const params = `${Object.entries(parameters).map(entry => `${entry[0]}=${entry[1]}`).join('&')}`
+  return params ? `&${params}` : ''
 }

--- a/src/main.js
+++ b/src/main.js
@@ -71,7 +71,11 @@ if (urlParams.has('example')) {
   showExample(properties)
 } else {
   const examplesToList = showExperimental ? examples : examples.filter(example => !example.experimental)
-  const properties = { examples: examplesToList, showExample: showExample }
+  const properties = {
+    examples: examplesToList,
+    additionalUrlParameters: urlParams.has('localDevelopment') ? '&localDevelopment=true' : '',
+    showExample: showExample
+  }
   loadTemplate('navigation.hbs', properties, () => null)
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,12 +1,16 @@
 /* global $ _ Prism Handlebars */
 
+const GITHUB_PAGES_URL = 'https://transportapi.github.io/usage-examples/src/'
+const RAW_GITHUB_CONTENT_URL = 'https://raw.githubusercontent.com/transportapi/usage-examples/master/'
+
 const urlParams = new URLSearchParams(window.location.search)
 const showExperimental =
   urlParams.has('showExperimental') ? JSON.parse(urlParams.get('showExperimental')) : false
+const gitBranch = urlParams.has('branch') ? urlParams.get('branch') : 'master'
 
-const BRANCH = urlParams.has('branch') ? urlParams.get('branch') : 'master'
-const GITHUB_PAGES_URL = 'https://transportapi.github.io/usage-examples/src/'
-const RAW_GITHUB_CONTENT_ROOT = `https://raw.githubusercontent.com/transportapi/usage-examples/${BRANCH}/`
+// For local development load the files from a relative path
+const examplesRootUrl = urlParams.has('localDevelopment') ? '../' : RAW_GITHUB_CONTENT_URL
+const pageTemplatesRootUrl = urlParams.has('localDevelopment') ? '' : GITHUB_PAGES_URL
 
 const examples = [
   {
@@ -72,17 +76,17 @@ if (urlParams.has('example')) {
 }
 
 function loadTemplate (fileName, properties, onLoad) {
-  $.get(RAW_GITHUB_CONTENT_ROOT + 'src/' + fileName, templateSource => {
+  $.get(pageTemplatesRootUrl + fileName, templateSource => {
     const template = Handlebars.compile(templateSource)
 
-    properties.root_url = GITHUB_PAGES_URL
+    properties.root_url = pageTemplatesRootUrl
     const html = template(properties)
     $('#app').html(html)
     onLoad()
   })
 }
 
-const exampleFile = RAW_GITHUB_CONTENT_ROOT + 'examples/{{directory}}/{{name}}'
+const exampleFile = examplesRootUrl + 'examples/{{directory}}/{{name}}'
 const fileHtml = `
   <h2 class="source-title">{{name}}</h2>
   <pre class="line-numbers"
@@ -93,8 +97,8 @@ const fileHtml = `
 Handlebars.registerPartial('file', fileHtml)
 
 function showExample (exampleProperties) {
-  exampleProperties.root_url = GITHUB_PAGES_URL
-  exampleProperties.branch = BRANCH
+  exampleProperties.root_url = pageTemplatesRootUrl
+  exampleProperties.branch = gitBranch
 
   loadTemplate('example.hbs', exampleProperties, () => {
     // This can't simply be put in the CSS file because Prism.js seemingly redraws the element

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,12 @@
 /* global $ _ Prism Handlebars */
 
-const ROOT_URL = 'https://transportapi.github.io/usage-examples/src/'
+const urlParams = new URLSearchParams(window.location.search)
+const showExperimental =
+  urlParams.has('showExperimentalExamples') ? JSON.parse(urlParams.get('showExperimentalExamples')) : false
+
+const BRANCH = urlParams.has('branch') ? urlParams.get('branch') : 'master'
+const GITHUB_PAGES_URL = 'https://transportapi.github.io/usage-examples/src/'
+const RAW_GITHUB_CONTENT_ROOT = `https://raw.githubusercontent.com/transportapi/usage-examples/${BRANCH}/`
 
 const examples = [
   {
@@ -8,77 +14,88 @@ const examples = [
     description: 'Retrieves information about all buses departing from a stop with a given ATCOCode in the near ' +
       'future',
     directory: 'bus-stop-timetable',
+    experimental: false
   },
   {
     title: 'Bus route geometry',
     description: 'Retrieves the geometry of a bus route specified by operator, line and direction and draws it on a ' +
       'map',
     directory: 'bus-route-geometry',
+    experimental: false
   },
   {
     title: 'Bus service description',
     description: 'Show bus service metadata: the operator, linename, directions and destinations',
     directory: 'bus-service-description',
+    experimental: false
   },
   {
     title: 'Bus service search',
     description: 'List bus services matching the search on operator code and line name',
     directory: 'bus-service-search',
+    experimental: false
   },
   {
     title: 'Bus journey timetable',
     description: 'Show the scheduled timing point stops for a specific bus journey',
     directory: 'bus-journey-timetable',
+    experimental: false
   },
   {
     title: 'Buses on a map',
     description: 'Show the buses for a specific service on a map',
     directory: 'buses-on-a-map',
+    experimental: false
   },
   {
     title: 'Bus full timetable',
     description: 'Show the full timetable for a given service on a given date',
     directory: 'bus-full-timetable',
+    experimental: false
   },
   {
     title: 'Journey planner',
     description: 'Shows a journey plan between two points',
     directory: 'journey-planner',
-  },
+    experimental: false
+  }
 ]
 
-const urlParams = new URLSearchParams(window.location.search)
 if (urlParams.has('example')) {
   const directory = urlParams.get('example')
   const properties = _.find(examples, { directory })
   showExample(properties)
 } else {
-  const properties = { examples: examples, showExample: showExample }
+  const examplesToList = showExperimental ? examples : examples.filter(example => !example.experimental)
+  const properties = { examples: examplesToList, showExample: showExample }
   loadTemplate('navigation.hbs', properties, () => null)
 }
 
 function loadTemplate (fileName, properties, onLoad) {
-  $.get(ROOT_URL + fileName, templateSource => {
+  $.get(RAW_GITHUB_CONTENT_ROOT + 'src/' + fileName, templateSource => {
     const template = Handlebars.compile(templateSource)
 
-    properties.root_url = ROOT_URL
+    properties.root_url = GITHUB_PAGES_URL
     const html = template(properties)
     $('#app').html(html)
     onLoad()
   })
 }
 
+const exampleFile = RAW_GITHUB_CONTENT_ROOT + 'examples/{{directory}}/{{name}}'
 const fileHtml = `
   <h2 class="source-title">{{name}}</h2>
   <pre class="line-numbers"
        data-download-link
-       data-src="https://raw.githubusercontent.com/transportapi/usage-examples/master/examples/{{directory}}/{{name}}"
+       data-src="${exampleFile}"
   ><code id="{{name}}" {{#if language}}class="language-{{language}}{{/if}}"></code></pre>
 `
 Handlebars.registerPartial('file', fileHtml)
 
 function showExample (exampleProperties) {
-  exampleProperties.root_url = ROOT_URL
+  exampleProperties.root_url = GITHUB_PAGES_URL
+  exampleProperties.branch = BRANCH
+
   loadTemplate('example.hbs', exampleProperties, () => {
     // This can't simply be put in the CSS file because Prism.js seemingly redraws the element
     $('pre.line-numbers').css('max-height', '45em')

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
 
 const urlParams = new URLSearchParams(window.location.search)
 const showExperimental =
-  urlParams.has('showExperimental') ? JSON.parse(urlParams.get('showExperimentalExamples')) : false
+  urlParams.has('showExperimental') ? JSON.parse(urlParams.get('showExperimental')) : false
 
 const BRANCH = urlParams.has('branch') ? urlParams.get('branch') : 'master'
 const GITHUB_PAGES_URL = 'https://transportapi.github.io/usage-examples/src/'

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
 
 const urlParams = new URLSearchParams(window.location.search)
 const showExperimental =
-  urlParams.has('showExperimentalExamples') ? JSON.parse(urlParams.get('showExperimentalExamples')) : false
+  urlParams.has('showExperimental') ? JSON.parse(urlParams.get('showExperimentalExamples')) : false
 
 const BRANCH = urlParams.has('branch') ? urlParams.get('branch') : 'master'
 const GITHUB_PAGES_URL = 'https://transportapi.github.io/usage-examples/src/'

--- a/src/navigation.hbs
+++ b/src/navigation.hbs
@@ -2,7 +2,7 @@
 
 {{#each examples}}
   <div class="example-container">
-    <a class="example-box" href="?example={{directory}}{{../additionalUrlParameters}}">
+    <a class="example-box" href="?example={{directory}}{{../additionalUrlQueryParams}}">
       <h2>{{title}}</h2>
       {{description}}
     </a>

--- a/src/navigation.hbs
+++ b/src/navigation.hbs
@@ -2,7 +2,7 @@
 
 {{#each examples}}
   <div class="example-container">
-    <a class="example-box" href="?example={{directory}}">
+    <a class="example-box" href="?example={{directory}}{{../additionalUrlParameters}}">
       <h2>{{title}}</h2>
       {{description}}
     </a>


### PR DESCRIPTION
Ticket: [Introduce peer review process for the usage examples](https://kanbanzone.io/b/YA2t2Uox/c/696-Introduce-peer-review-process-for-the-usage-examples)

1. Add option to add experimental examples - examples that will be listed on the index page only if `showExperimental` request param is provided.
2. Improvements to be able to load pages of individual examples locally (see the Readme)
3. Document the development and peer review process. 