### PR TITLE
Fix examples path

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -105,7 +105,7 @@ function loadTemplate (fileName, properties, onLoad) {
   })
 }
 
-const exampleFile = examplesRootUrl + 'examples/{{directory}}/{{name}}'
+const exampleFile = examplesRootUrl + 'src/examples/{{directory}}/{{name}}'
 const fileHtml = `
   <h2 class="source-title">{{name}}</h2>
   <pre class="line-numbers"


### PR DESCRIPTION
Required because the examples directory was moved to src/